### PR TITLE
fix(style): correct resource paths and enable CORS

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,5 @@
+<IfModule mod_headers.c>
+    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Methods "GET, POST, OPTIONS"
+    Header set Access-Control-Allow-Headers "Content-Type, Authorization"
+</IfModule>

--- a/src/Core/footer.php
+++ b/src/Core/footer.php
@@ -17,20 +17,20 @@
 <!-- REQUIRED SCRIPTS -->
 
 <!-- jQuery -->
-<script src="../assets/plugins/jquery/jquery.min.js"></script>
+<script src="http://localhost/calidad_restaurante/assets/plugins/jquery/jquery.min.js"></script>
 <!-- Bootstrap -->
-<script src="../assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+<script src="http://localhost/calidad_restaurante/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
 <!-- AdminLTE -->
-<script src="../assets/dist/js/adminlte.min.js"></script>
+<script src="http://localhost/calidad_restaurante/assets/dist/js/adminlte.min.js"></script>
 
-<script src="../assets/plugins/chart.js/Chart.min.js"></script>
+<script src="http://localhost/calidad_restaurante/assets/plugins/chart.js/Chart.min.js"></script>
 
 <!-- OPTIONAL SCRIPTS -->
-<script src="../assets/plugins/datatables/jquery.dataTables.min.js"></script>
-<script src="../assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
+<script src="http://localhost/calidad_restaurante/assets/plugins/datatables/jquery.dataTables.min.js"></script>
+<script src="http://localhost/calidad_restaurante/assets/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
 
-<script src="../assets/js/sweetalert2.all.min.js"></script>
-<script src="../assets/js/funciones.js"></script>
+<script src="http://localhost/calidad_restaurante/assets/js/sweetalert2.all.min.js"></script>
+<script src="http://localhost/calidad_restaurante/assets/js/funciones.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/qr-code-styling/lib/qr-code-styling.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 

--- a/src/Core/header.php
+++ b/src/Core/header.php
@@ -2,6 +2,10 @@
 if (empty($_SESSION['active'])) {
     header('Location: ../');
 }
+
+header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
+header("Access-Control-Allow-Headers: Content-Type, Authorization");
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -14,12 +18,15 @@ if (empty($_SESSION['active'])) {
     <!-- Google Font: Source Sans Pro -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
     <!-- Font Awesome Icons -->
-    <link rel="stylesheet" href="../assets/plugins/fontawesome-free/css/all.min.css">
+    <!-- <link rel="stylesheet" href="../assets/plugins/fontawesome-free/css/all.min.css"> -->
+    <link rel="stylesheet" href="http://localhost/calidad_restaurante/assets/plugins/fontawesome-free/css/all.min.css">
     <!-- IonIcons -->
     <link rel="stylesheet" href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
     <!-- Theme style -->
-    <link rel="stylesheet" href="../assets/dist/css/adminlte.min.css">
-    <link rel="stylesheet" href="../assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
+    <!-- <link rel="stylesheet" href="../assets/dist/css/adminlte.min.css"> -->
+    <link rel="stylesheet" href="http://localhost/calidad_restaurante/assets/dist/css/adminlte.min.css">
+    <!-- <link rel="stylesheet" href="../assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css"> -->
+    <link rel="stylesheet" href="http://localhost/calidad_restaurante/assets/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
 </head>
 
 <body class="hold-transition sidebar-mini">
@@ -49,7 +56,7 @@ if (empty($_SESSION['active'])) {
         <aside class="main-sidebar sidebar-dark-primary elevation-4">
             <!-- Brand Logo -->
             <a href="dashboard.php" class="brand-link">
-                <img src="../assets/img/logo.png" alt="AdminLTE Logo" class="brand-image img-circle elevation-3" style="opacity: .8">
+                <img src="http://localhost/calidad_restaurante/assets/img/logo.png" alt="AdminLTE Logo" class="brand-image img-circle elevation-3" style="opacity: .8">
                 <span class="brand-text font-weight-light">RestBAR</span>
             </a>
 

--- a/src/Views/dashboard.php
+++ b/src/Views/dashboard.php
@@ -86,4 +86,4 @@ include_once "../src/Core/header.php";
     </div>
 </div>
 <?php include_once "../src/Core/footer.php"; ?>
-<script src="../assets/js/dashboard.js"></script>
+<script src="http://localhost/calidad_restaurante/assets/js/dashboard.js"></script>

--- a/src/Views/login.php
+++ b/src/Views/login.php
@@ -58,11 +58,6 @@
             <!-- /.login-card-body -->
         </div>
     </div>
-    <?php
-        echo '<pre>';
-        print_r(glob('../assets/*'));
-        echo '</pre>';
-    ?>
     <!-- jQuery -->
     <script src="../assets/plugins/jquery/jquery.min.js"></script>
     <!-- Bootstrap 4 -->

--- a/src/Views/login.php
+++ b/src/Views/login.php
@@ -18,6 +18,9 @@
 </head>
 
 <body class="hold-transition login-page">
+    
+
+
     <div class="login-box">
         <div class="login-logo">
             <a href="#"><b>Sistemas</b></a>
@@ -55,7 +58,11 @@
             <!-- /.login-card-body -->
         </div>
     </div>
-
+    <?php
+        echo '<pre>';
+        print_r(glob('../assets/*'));
+        echo '</pre>';
+    ?>
     <!-- jQuery -->
     <script src="../assets/plugins/jquery/jquery.min.js"></script>
     <!-- Bootstrap 4 -->

--- a/src/Views/login.php
+++ b/src/Views/login.php
@@ -10,11 +10,14 @@
     <link rel="stylesheet"
           href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
     <!-- Font Awesome -->
-    <link rel="stylesheet" href="../assets/plugins/fontawesome-free/css/all.min.css">
+    <!-- <link rel="stylesheet" href="../assets/plugins/fontawesome-free/css/all.min.css"> -->
+    <link rel="stylesheet" href="http://localhost/calidad_restaurante/assets/plugins/fontawesome-free/css/all.min.css">
     <!-- icheck bootstrap -->
-    <link rel="stylesheet" href="../assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
+    <!-- <link rel="stylesheet" href="../assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css"> -->
+    <link rel="stylesheet" href="http://localhost/calidad_restaurante/assets/plugins/icheck-bootstrap/icheck-bootstrap.min.css">
     <!-- Theme style -->
-    <link rel="stylesheet" href="../assets/dist/css/adminlte.min.css">
+    <!-- <link rel="stylesheet" href="../assets/dist/css/adminlte.min.css"> -->
+    <link rel="stylesheet" href="http://localhost/calidad_restaurante/assets/dist/css/adminlte.min.css">
 </head>
 
 <body class="hold-transition login-page">
@@ -59,11 +62,14 @@
         </div>
     </div>
     <!-- jQuery -->
-    <script src="../assets/plugins/jquery/jquery.min.js"></script>
+    <!-- <script src="../assets/plugins/jquery/jquery.min.js"></script> -->
+    <script src="http://localhost/calidad_restaurante/assets/plugins/jquery/jquery.min.js"></script>
     <!-- Bootstrap 4 -->
-    <script src="../assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <!-- <script src="../assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script> -->
+    <script src="http://localhost/calidad_restaurante/assets/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
     <!-- AdminLTE App -->
-    <script src="../assets/dist/js/adminlte.min.js"></script>
+    <!-- <script src="/assets/dist/js/adminlte.min.js"></script> -->
+    <script src="http://localhost/calidad_restaurante/assets/dist/js/adminlte.min.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
The paths for most resources weren't working, so I corrected them by changing ../assets/plugins/fontawesome-free/css/all.min.css to http://localhost/calidad_restaurante/assets/plugins/fontawesome-free/css/all.min.css. This fix also affected the icons, as they weren't loading correctly due to CORS policies, so I added additional code to enable them as well.

Note: It's possible that other paths on pages still in development may also need updating.